### PR TITLE
Draft for formatted XML preview.

### DIFF
--- a/R/mod_xml_report.R
+++ b/R/mod_xml_report.R
@@ -134,7 +134,9 @@ mod_xml_report_server <- function(id, input_data){
     modal <- function() {
       modalDialog(
         rclipboard::rclipboardSetup(),
-        textOutput(NS(id, "xml_path")),
+        h3("JATS XML"),
+        p("The Journal Article Tag Suite (JATS) is an XML format used to describe scientific literature published online.", a("Find out more about JATS XML.", href = "https://en.wikipedia.org/wiki/Journal_Article_Tag_Suite")),
+        verbatimTextOutput(NS(id, "xml_path")),
         easyClose = TRUE,
         footer = tagList(
           div(


### PR DESCRIPTION
This implements a draft suggestion for structured preview of JATS XML (#5). It is simpler than what I have previously done for YAML. I omits the intermediate step of rendering an R Markdown document and immediately creates the HTML for the modal. This should speed things up and save resources. If you like it, I would implement the same approach for the YAML modal.

To make this even prettier, we could add syntax highlighting for the verbatim code.