### PR TITLE
Adds CITATION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: tenzing
-Title: Handling Contributorship Information
+Title: Documenting contributions to scientific scholarly output with CRediT
 Version: 0.0.0.9000
 Authors@R:
   c(person(given = "Marton",
@@ -18,7 +18,7 @@ Authors@R:
     person(given = "Balazs", 
            family = "Aczel",
            role = "ctb"))
-Description: A modularized shiny app that read contributorship information from a local source and produces human and machine-readable summaries.
+Description: A modularized shiny app that reads contributorship information from a local source and produces human and machine-readable summaries.
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,13 +1,13 @@
-citHeader("To cite tenzing the software, use Kovacs et al. (2020); for an introduction to tenzing cite Holcombe et al. (2020).")
+citHeader("To cite tenzing the software, use Kovacs et al. (2020); for the introductory paper cite Holcombe et al. (2020).")
 
 bibentry(
   bibtype = "misc",
-  title = "{tenzing}: {A} web app and R-package to document contributorship with {CRediT}",
+  title = "{tenzing}: {D}ocumenting contributions to scientific scholarly output with {CRediT}",
   author = "Marton Kovacs and  Fredrik Aust and Alex O. Holcombe and Balazs Aczel",
   year = "2020",
   note = "R package version 0.1.0",
   url = "https://github.com/marton-balazs-kovacs/tenzing",
-  textVersion = "Kovacs, M., Aust, F., Holcombe, A. O., & Aczel, B. (2020). tenzing: A web app and R-package to document contributorship with CRediT.
+  textVersion = "Kovacs, M., Aust, F., Holcombe, A. O., & Aczel, B. (2020). tenzing: Documenting contributions to scientific scholarly output with CRediT.
   R package version 0.1.0. Retrieved from https://github.com/marton-balazs-kovacs/tenzing"
 )
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,27 @@
+citHeader("To cite tenzing the software, use Kovacs et al. (2020); for an introduction to tenzing cite Holcombe et al. (2020).")
+
+bibentry(
+  bibtype = "misc",
+  title = "{tenzing}: {A} web app and R-package to document contributorship with {CRediT}",
+  author = "Marton Kovacs and  Fredrik Aust and Alex O. Holcombe and Balazs Aczel",
+  year = "2020",
+  note = "R package version 0.1.0",
+  url = "https://github.com/marton-balazs-kovacs/tenzing",
+  textVersion = "Kovacs, M., Aust, F., Holcombe, A. O., & Aczel, B. (2020). tenzing: A web app and R-package to document contributorship with CRediT.
+  R package version 0.1.0. Retrieved from https://github.com/marton-balazs-kovacs/tenzing"
+)
+
+bibentry(
+  bibtype = "article",
+  title = "{tenzing}: {A} web app to document contributorship with {CRediT}",
+  journal = "MetaArXiv",
+  author = "Alex O. Holcombe and Marton Kovacs and Fredrik Aust and Balazs Aczel",
+  year = "2020",
+  # volume = "73",
+  # number = "1",
+  # pages = "3-36",
+  # doi = "",
+  # url = "",
+  textVersion = "Holcombe, A. O., Kovacs, M., Aust, F., & Aczel, B. (2020). tenzing: A web app to document contributorship with CRediT.
+  MetaArXiv."
+)


### PR DESCRIPTION
As discussed this adds a CITATION file, which produces the following output:

~~~r
citation("tenzing")
~~~

~~~
To cite tenzing the software, use
Kovacs et al. (2020); for an
introduction to tenzing cite Holcombe
et al. (2020).

   Kovacs, M., Aust, F., Holcombe, A.
   O., & Aczel, B. (2020). tenzing: Documenting
   contributions to scientific scholarly output with
   CRediT. R package version 0.1.0. Retrieved
   from
   https://github.com/marton-balazs-kovacs/tenzing

   Holcombe, A. O., Kovacs, M., Aust,
   F., & Aczel, B. (2020). tenzing: A
   web app to document contributorship
   with CRediT. MetaArXiv.
~~~

Once the preprint is out, we can update this to include to preprint DOI.