### PR TITLE
Record message for usage tracking

### DIFF
--- a/R/mod_read_spreadsheet.R
+++ b/R/mod_read_spreadsheet.R
@@ -95,7 +95,8 @@ mod_read_spreadsheet_server <- function(id) {
                          list(error = read_output$error[["message"]],
                               warning = ""))
         return(NULL)
-        } else {
+        } else { #have successfully read the file or Google Sheet
+          message("File or Google Sheet has been uploaded.") #Print message for logfile so we know when people have uploaded a contributor table
           return(read_output$result)
           }
       })


### PR DESCRIPTION
Resolve [issue 77](https://github.com/marton-balazs-kovacs/tenzing/issues/77) (usage tracking) by printing message to log file when user uploads contributor table.