### PR TITLE
Small improvement: Use the post-fix `template/preview` for the link to the google sheet

### DIFF
--- a/R/mod_create_table.R
+++ b/R/mod_create_table.R
@@ -18,7 +18,7 @@ mod_create_table_ui <- function(id) {
     p("Duplicate and edit the ",
       style = "display: inline; margin-bottom: 0;"),
     a(
-      href = "https://docs.google.com/spreadsheets/d/1ay8pS-ftvfzWTrKCZr6Fa0cTLg3n8KxAOOleZmuE7Hs/edit?usp=sharing",
+      href = "https://docs.google.com/spreadsheets/d/1ay8pS-ftvfzWTrKCZr6Fa0cTLg3n8KxAOOleZmuE7Hs/template/preview",
       "contributors table template",
       target = "_blank",
       style = "display: inline; color: #ffdf57; text-decoration: underline;",


### PR DESCRIPTION
This opens in a nice view of the sheet and a "Use template" button in the top right corner of the screen:

![image](https://github.com/user-attachments/assets/7b60534f-f082-4fd5-8ad7-7651486170b7)
