### PR TITLE
Fixes indexing error in print_yaml()

### DIFF
--- a/R/print_title_page.R
+++ b/R/print_title_page.R
@@ -150,10 +150,13 @@ print_title_page <- function(contributors_table,
       values_to = "affiliation"
     ) %>%
     dplyr::arrange(.data$`Order in publication`) %>%
-    dplyr::mutate(affiliation_no = dplyr::case_when(
-      !is.na(affiliation) ~ suppressWarnings(dplyr::group_indices(., factor(affiliation, levels = unique(affiliation)))),
-      is.na(affiliation) ~ NA_integer_
-    ))
+    dplyr::mutate(
+      affiliation_no = dplyr::if_else(
+        is.na(affiliation),
+        NA_integer_,
+        as.integer(factor(affiliation, levels = unique(affiliation)))
+      )
+    )
   
   # Modify data for printing contributor information ---------------------------
   contrib_entries <-

--- a/R/print_yaml.R
+++ b/R/print_yaml.R
@@ -73,10 +73,11 @@ print_yaml <- function(contributors_table) {
     dplyr::mutate(name = factor(name, levels = name))
   
   # Generate role assignments
+  credit_roles <- dplyr::pull(credit_taxonomy, `CRediT Taxonomy`)
   contrib_data$role <- I(
     purrr::map(
       split(contrib_data, contrib_data$name),
-      ~ names(dplyr::select(., dplyr::pull(credit_taxonomy, `CRediT Taxonomy`)))[.x[1, ] == TRUE]
+      ~ names(dplyr::select(., dplyr::all_of(credit_roles)))[.x[1, credit_roles] == TRUE]
     )
   )
   

--- a/R/print_yaml.R
+++ b/R/print_yaml.R
@@ -76,7 +76,7 @@ print_yaml <- function(contributors_table) {
   contrib_data$role <- I(
     purrr::map(
       split(contrib_data, contrib_data$name),
-      ~ names(dplyr::select(., dplyr::pull(credit_taxonomy, `CRediT Taxonomy`)))[.x[1, -c(1:4)] == TRUE]
+      ~ names(dplyr::select(., dplyr::pull(credit_taxonomy, `CRediT Taxonomy`)))[.x[1, ] == TRUE]
     )
   )
   

--- a/man/mod_support_popup_server.Rd
+++ b/man/mod_support_popup_server.Rd
@@ -10,7 +10,7 @@ mod_support_popup_server(
   enable = TRUE,
   show_prob = 0.33,
   delay_ms = 1500,
-  dismiss_ms = 15000,
+  dismiss_ms = 60000,
   donation_url = "https://opencollective.com/tenzing"
 )
 }


### PR DESCRIPTION
Hi Marton,

preparing a manuscript, I noticed that previous updates appear to have introduced an indexing error in the assembly of the contributiorship roles, when the papaja-YAML is produced.

This small change should fix this.

Cheers,
Frederik